### PR TITLE
Add additonal bazel options for coverage

### DIFF
--- a/server/bazelrunner/src/main/kotlin/org/jetbrains/bazel/bazelrunner/BazelCommand.kt
+++ b/server/bazelrunner/src/main/kotlin/org/jetbrains/bazel/bazelrunner/BazelCommand.kt
@@ -219,12 +219,14 @@ abstract class BazelCommand(val bazelBinary: String) {
     BazelCommand(bazelBinary),
     HasEnvironment,
     HasMultipleTargets,
-    HasProgramArguments {
+    HasProgramArguments,
+    HasAdditionalBazelOptions {
     override val targets: MutableList<Label> = mutableListOf()
     override val excludedTargets: MutableList<Label> = mutableListOf()
     override val environment: MutableMap<String, String> = mutableMapOf()
     override val inheritedEnvironment: MutableList<String> = mutableListOf()
     override val programArguments: MutableList<String> = mutableListOf()
+    override val additionalBazelOptions: MutableList<String> = mutableListOf()
 
     override fun buildExecutionDescriptor(): BazelCommandExecutionDescriptor {
       val commandLine = mutableListOf(bazelBinary)
@@ -232,6 +234,7 @@ abstract class BazelCommand(val bazelBinary: String) {
       commandLine.addAll(startupOptions)
       commandLine.add("coverage")
       commandLine.addAll(options)
+      commandLine.addAll(additionalBazelOptions)
       commandLine.addAll(environment.map { (key, value) -> "--test_env=$key=$value" })
       commandLine.addAll(inheritedEnvironment.map { "--test_env=$it" })
       commandLine.addAll(programArguments.map { "--test_arg=$it" })

--- a/server/bazelrunner/src/test/kotlin/org/jetbrains/bazel/bazelrunner/BazelRunnerBuilderTest.kt
+++ b/server/bazelrunner/src/test/kotlin/org/jetbrains/bazel/bazelrunner/BazelRunnerBuilderTest.kt
@@ -318,6 +318,7 @@ class BazelRunnerBuilderTest {
     val command =
       bazelRunner.buildBazelCommand(mockContext) {
         coverage {
+          additionalBazelOptions.add("--additional-bazel-options")
           targets.add("in1".label())
           programArguments.addAll(listOf("hello", "world"))
           environment["key"] = "value"
@@ -335,6 +336,7 @@ class BazelRunnerBuilderTest {
         "--noprogress_in_terminal_title",
         "flag1",
         "flag2",
+        "--additional-bazel-options",
         "--test_env=key=value",
         "--test_arg=hello",
         "--test_arg=world",


### PR DESCRIPTION
It's possible for bazel coverage command to have additional bazel options as well. This can be used for cases where users want to pass custom tags or test args from command line. 
