### PR TITLE
chore: enable e2e tests

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -13,7 +13,7 @@ jobs:
         os:
           - ubuntu-latest # x86_64-linux
           - macos-latest # aarch64-darwin
-          #          - macos-13      # x86_64-darwin
+          #- macos-13      # x86_64-darwin
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -34,6 +34,6 @@ jobs:
       - name: Run tests
         run: |
           bazel test //server/...
-    #- name: Run e2e tests
-    #  run: |
-    #    bazel test //server/e2e:all_tests --test_tag_filters=-ci-disabled
+      - name: Run e2e tests
+        run: |
+          bazel test //server/e2e:all_tests --test_tag_filters=-ci-disabled

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -207,7 +207,7 @@ bazel_binaries = use_extension(
 
 # test project are too old for bazel 7
 # bazel_binaries.download(version_file = "//:.bazelversion")
-bazel_binaries.download(version = "8.0.0")
+bazel_binaries.download(version = "8.2.1")
 bazel_binaries.download(version = "7.4.0")
 bazel_binaries.download(version = "6.4.0")
 use_repo(
@@ -216,5 +216,5 @@ use_repo(
     "bazel_binaries_bazelisk",
     "build_bazel_bazel_6_4_0",
     "build_bazel_bazel_7_4_0",
-    "build_bazel_bazel_8_0_0",
+    "build_bazel_bazel_8_2_1",
 )

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1054,7 +1054,7 @@
     "@@rules_bazel_integration_test+//:extensions.bzl%bazel_binaries": {
       "general": {
         "bzlTransitiveDigest": "Y2ghqnfOtrUWDGPyZA2c5xAT0bu3Q36eD3LittRFhQQ=",
-        "usagesDigest": "8N2yriz3By3SxKmwKLxgdZlHqAYlMMnYJCYUwtc2yuc=",
+        "usagesDigest": "iWdAdE5d2hzD5M9CvX6fUfPLlnWidqf0j6lTw9m2g7g=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1065,10 +1065,10 @@
               "version": "1.18.0"
             }
           },
-          "build_bazel_bazel_8_0_0": {
+          "build_bazel_bazel_8_2_1": {
             "repoRuleId": "@@rules_bazel_integration_test+//bazel_integration_test/private:bazel_binaries.bzl%bazel_binary",
             "attributes": {
-              "version": "8.0.0",
+              "version": "8.2.1",
               "bazelisk": "@bazel_binaries_bazelisk//:bazelisk"
             }
           },
@@ -1090,11 +1090,11 @@
             "repoRuleId": "@@rules_bazel_integration_test+//bazel_integration_test/bzlmod:bazel_binaries.bzl%_bazel_binaries_helper",
             "attributes": {
               "version_to_repo": {
-                "8.0.0": "build_bazel_bazel_8_0_0",
+                "8.2.1": "build_bazel_bazel_8_2_1",
                 "7.4.0": "build_bazel_bazel_7_4_0",
                 "6.4.0": "build_bazel_bazel_6_4_0"
               },
-              "current_version": "8.0.0"
+              "current_version": "8.2.1"
             }
           }
         },
@@ -1102,7 +1102,7 @@
           "explicitRootModuleDirectDeps": [],
           "explicitRootModuleDirectDevDeps": [
             "bazel_binaries_bazelisk",
-            "build_bazel_bazel_8_0_0",
+            "build_bazel_bazel_8_2_1",
             "build_bazel_bazel_7_4_0",
             "build_bazel_bazel_6_4_0",
             "bazel_binaries"

--- a/plugin-bazel/rules/bazel_integration_test/defs.bzl
+++ b/plugin-bazel/rules/bazel_integration_test/defs.bzl
@@ -20,7 +20,7 @@ def bazel_integration_test_all_versions(name, test_runner, project_path = None, 
         )
 
     if bzlmod_project_path != None:
-        bzlmod_bazel_versions = ["7.4.0", "8.0.0"]
+        bzlmod_bazel_versions = ["7.4.0", "8.2.1"]
         bazel_versions += bzlmod_bazel_versions
 
         bazel_integration_tests(

--- a/server/e2e/src/main/kotlin/org/jetbrains/bsp/bazel/NestedModulesTest.kt
+++ b/server/e2e/src/main/kotlin/org/jetbrains/bsp/bazel/NestedModulesTest.kt
@@ -98,6 +98,7 @@ object NestedModulesTest : BazelBspTestBaseScenario() {
             "bazelbsp_aspect" to "+_repo_rules+bazelbsp_aspect",
             "local_config_platform" to "local_config_platform",
             "rules_java" to "rules_java+",
+            "rules_python" to "rules_python+",
             "bazel_tools" to "bazel_tools",
             "outer" to "",
             "inner" to "inner+",

--- a/server/e2e/test-projects/bzlmod/allow-manual-targets-sync-project/MODULE.bazel
+++ b/server/e2e/test-projects/bzlmod/allow-manual-targets-sync-project/MODULE.bazel
@@ -1,3 +1,4 @@
-module(name = "allow_manula_targets_sync")
+module(name = "allow_manual_targets_sync")
 
 bazel_dep(name = "rules_java", version = "8.6.2")
+bazel_dep(name = "rules_python", version = "1.0.0")

--- a/server/e2e/test-projects/bzlmod/build-and-sync-test/MODULE.bazel
+++ b/server/e2e/test-projects/bzlmod/build-and-sync-test/MODULE.bazel
@@ -1,3 +1,3 @@
 module(name = "build_and_sync")
-
+bazel_dep(name = "rules_python", version = "1.0.0")
 bazel_dep(name = "rules_java", version = "8.6.2")

--- a/server/e2e/test-projects/bzlmod/kotlin-project/MODULE.bazel
+++ b/server/e2e/test-projects/bzlmod/kotlin-project/MODULE.bazel
@@ -1,5 +1,5 @@
 bazel_dep(name = "rules_kotlin", version = "2.0.0")
-
+bazel_dep(name = "rules_python", version = "1.0.0")
 register_toolchains(
     "//:my_kotlin_toolchain",
 )

--- a/server/e2e/test-projects/bzlmod/nested-modules/MODULE.bazel
+++ b/server/e2e/test-projects/bzlmod/nested-modules/MODULE.bazel
@@ -1,7 +1,7 @@
 module(
     name = "outer",
 )
-
+bazel_dep(name = "rules_python", version = "1.0.0")
 bazel_dep(name = "rules_java", version = "8.6.2")
 bazel_dep(
     name = "inner",

--- a/server/e2e/test-projects/bzlmod/remote-jdk-project/MODULE.bazel
+++ b/server/e2e/test-projects/bzlmod/remote-jdk-project/MODULE.bazel
@@ -1,3 +1,3 @@
 module(name = "remote_jdk")
-
+bazel_dep(name = "rules_python", version = "1.0.0")
 bazel_dep(name = "rules_java", version = "8.6.2")

--- a/server/e2e/test-projects/bzlmod/sample-repo/MODULE.bazel
+++ b/server/e2e/test-projects/bzlmod/sample-repo/MODULE.bazel
@@ -1,6 +1,7 @@
 module(name = "sample_repo")
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "rules_python", version = "1.0.0")
 bazel_dep(name = "rules_java", version = "8.6.2")
 bazel_dep(name = "rules_jvm_external", version = "6.6")
 


### PR DESCRIPTION
Bazel8 failures were related with the inclusion of @rules_python somewhere within the aspect. Bzlmod visibility approach prevents from the usage of transitive dependencies so I had to explicitly list rules_python as dep within corresponding MODULE.bazel files. However, hirschgarten project have probably solved it in a different way which I haven't found. Nevertheless, it works with this fix. 