### PR TITLE
[bazel] [fix] Don't use --inject_repository with --noenable_bzlmod

### DIFF
--- a/server/bazelrunner/src/main/kotlin/org/jetbrains/bsp/bazel/bazelrunner/params/BazelFlag.kt
+++ b/server/bazelrunner/src/main/kotlin/org/jetbrains/bsp/bazel/bazelrunner/params/BazelFlag.kt
@@ -28,7 +28,7 @@ object BazelFlag {
   @JvmStatic fun overrideRepository(
     repositoryName: String,
     path: String,
-    shouldUseInjectRepository: Boolean = false,
+    shouldUseInjectRepository: Boolean,
   ): String =
     if (shouldUseInjectRepository) {
       arg("inject_repository", "$repositoryName=$path")

--- a/server/bazelrunner/src/main/kotlin/org/jetbrains/bsp/bazel/bazelrunner/utils/BazelInfo.kt
+++ b/server/bazelrunner/src/main/kotlin/org/jetbrains/bsp/bazel/bazelrunner/utils/BazelInfo.kt
@@ -13,7 +13,7 @@ data class BazelInfo(
   val isBzlModEnabled: Boolean,
   val isWorkspaceEnabled: Boolean,
 ) {
-  fun shouldUseInjectRepository(): Boolean = release.major >= 8
+  fun shouldUseInjectRepository(): Boolean = isBzlModEnabled && release.major >= 8
 
   fun dotBazelBsp(): Path = workspaceRoot.resolve(DOT_BAZELBSP_DIR_NAME)
 }


### PR DESCRIPTION
`--inject_repository` is a no-op with `--noenable_bzlmod` and `--override_repository` should be used instead.

Copied directly from:
https://github.com/JetBrains/hirschgarten/commit/a41862513ff3b4dc359d9f8dfc32637c8794b4b5