### PR TITLE
chore: Use centrally set BSP version and base it on the current tag i…

### DIFF
--- a/commons/src/main/kotlin/org/jetbrains/bazel/commons/constants/Constants.kt
+++ b/commons/src/main/kotlin/org/jetbrains/bazel/commons/constants/Constants.kt
@@ -2,7 +2,7 @@ package org.jetbrains.bazel.commons.constants
 
 object Constants {
   const val NAME: String = "bazelbsp"
-  const val VERSION: String = "4.0.1"
+  const val VERSION: String = System.getenv("BAZEL_BSP_ARTIFACT_VERSION")
   const val BSP_VERSION: String = "2.1.0"
   const val SCALA: String = "scala"
   const val JAVA: String = "java"


### PR DESCRIPTION
…f available