### PR TITLE
Parse Jest test results from system-out

### DIFF
--- a/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/bep/JestTestOutputParser.kt
+++ b/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/bep/JestTestOutputParser.kt
@@ -1,0 +1,110 @@
+package org.jetbrains.bsp.bazel.server.bep
+
+import ch.epfl.scala.bsp4j.TaskId
+import ch.epfl.scala.bsp4j.TestStatus
+import org.jetbrains.bsp.bazel.logger.BspClientTestNotifier
+import org.jetbrains.bsp.protocol.JUnitStyleTestCaseData
+import java.util.UUID
+
+class JestTestOutputParser(private val bspClientTestNotifier: BspClientTestNotifier) {
+  private val suiteStack = ArrayDeque<JestSuite>()
+
+  fun processTestOutput(output: String) {
+    output.lines().forEach { rawLine ->
+      val line = rawLine.removeJestFormat().trimEnd()
+      val testLine = parseTestLine(line)
+      if (testLine != null) {
+        emitTest(testLine)
+        return@forEach
+      }
+
+      parseSuiteLine(line)?.let { suite ->
+        while (suiteStack.isNotEmpty() && suite.indent <= suiteStack.last().indent) {
+          suiteStack.removeLast()
+        }
+        suiteStack.addLast(suite)
+      }
+    }
+  }
+
+  private fun emitTest(testLine: JestTestLine) {
+    val activeSuites = suiteStack.filter { it.indent < testLine.indent }.map { it.name }
+    val lookupKey = (activeSuites + testLine.name).joinToString(" ")
+    val taskId = TaskId("test-" + UUID.randomUUID().toString())
+    val testCaseData =
+      JUnitStyleTestCaseData(
+        time = null,
+        className = lookupKey,
+        errorMessage = null,
+        errorContent = null,
+        errorType = null,
+      )
+
+    bspClientTestNotifier.startTest(testLine.name, taskId)
+    bspClientTestNotifier.finishTest(
+      displayName = testLine.name,
+      taskId = taskId,
+      status = testLine.status,
+      message = null,
+      dataKind = JUnitStyleTestCaseData.DATA_KIND,
+      data = testCaseData,
+    )
+  }
+
+  private fun parseTestLine(line: String): JestTestLine? {
+    val match = testLinePattern.matchEntire(line) ?: return null
+    val status =
+      when (match.groups["status"]?.value) {
+        "✓", "✔", "√" -> TestStatus.PASSED
+        "✕", "✖", "×" -> TestStatus.FAILED
+        "○", "↷" -> TestStatus.SKIPPED
+        else -> return null
+      }
+    return JestTestLine(
+      indent = match.groups["indent"]?.value?.length ?: 0,
+      status = status,
+      name =
+        match.groups["name"]
+          ?.value
+          ?.trim()
+          .orEmpty(),
+    )
+  }
+
+  private fun parseSuiteLine(line: String): JestSuite? {
+    val match = suiteLinePattern.matchEntire(line) ?: return null
+    return JestSuite(
+      indent = match.groups["indent"]?.value?.length ?: 0,
+      name =
+        match.groups["name"]
+          ?.value
+          ?.trim()
+          .orEmpty(),
+    )
+  }
+
+  companion object {
+    fun textContainsJestOutput(text: String): Boolean {
+      val cleanText = text.removeJestFormat()
+      return cleanText.contains("Test Suites:") &&
+        cleanText.contains("Tests:") &&
+        cleanText.lines().any { testLinePattern.matches(it.trimEnd()) }
+    }
+  }
+}
+
+private val testLinePattern =
+  Regex("""^(?<indent>\s*)(?<status>[✓✔√✕✖×○↷])\s+(?<name>.+?)(?:\s+\(\d+(?:\.\d+)?\s*(?:m?s|μs|ns)\))?$""")
+
+private val suiteLinePattern =
+  Regex("""^(?<indent>\s{2,})(?<name>(?!(?:Test Suites|Tests|Snapshots|Time|Ran all test suites|Force exiting Jest):)\S.*)$""")
+
+private fun String.removeJestFormat(): String = this.replace(Regex("[?\u001b]\\[[;\\d]*m"), "")
+
+private data class JestSuite(val indent: Int, val name: String)
+
+private data class JestTestLine(
+  val indent: Int,
+  val status: TestStatus,
+  val name: String,
+)

--- a/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/bep/TestXmlParser.kt
+++ b/server/server/src/main/kotlin/org/jetbrains/bsp/bazel/server/bep/TestXmlParser.kt
@@ -271,6 +271,9 @@ private class FallbackTestXmlParser(private var bspClientTestNotifier: BspClient
     if (containsJunit5 == true) {
       val parser = Junit5TestVisualOutputParser(bspClientTestNotifier)
       parser.processTestOutput(suite.systemOut)
+    } else if (suite.systemOut?.let(JestTestOutputParser::textContainsJestOutput) == true) {
+      val parser = JestTestOutputParser(bspClientTestNotifier)
+      parser.processTestOutput(suite.systemOut)
     } else {
       defaultIncompleteInfoSuiteProcessing(suite)
     }

--- a/server/server/src/test/kotlin/org/jetbrains/bsp/bazel/server/bep/TestXmlParserTest.kt
+++ b/server/server/src/test/kotlin/org/jetbrains/bsp/bazel/server/bep/TestXmlParserTest.kt
@@ -746,6 +746,132 @@ class TestXmlParserTest {
   }
 
   @Test
+  fun `jest system-out - success failure and skipped`(
+    @TempDir tempDir: Path,
+  ) {
+    val sampleContents =
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <testsuites>
+        <testsuite name="sample/test" tests="1" failures="0" errors="1">
+          <testcase name="sample/test" status="run" duration="0" time="0"><error message="exited with error code 1"></error></testcase>
+          <system-out>
+      <![CDATA[Executing tests from //sample:test
+      -----------------------------------------------------------------------------
+      PASS node src/example/__tests__/sample.node.ts
+        loading state
+          ✕ renders (8 ms)
+        success state
+          ✓ renders (1 ms)
+        skipped state
+          ○ renders
+
+      Test Suites: 1 failed, 1 total
+      Tests:       1 failed, 1 skipped, 1 passed, 3 total
+      Snapshots:   0 total
+      Time:        1.315 s
+      Ran all test suites matching /src\/example\/__tests__\/sample.node.ts/i.]]>
+          </system-out>
+        </testsuite>
+      </testsuites>
+      """.trimIndent()
+
+    val client = MockBuildClient()
+    val notifier = BspClientTestNotifier(client, "sample-origin")
+
+    TestXmlParser(notifier).parseAndReport(writeTempFile(tempDir, sampleContents))
+
+    client.taskStartCalls.size shouldBe 3
+
+    val testFinishes = client.taskFinishCalls.filter { it.data is TestFinish }
+    testFinishes.map { (it.data as TestFinish).displayName } shouldContainExactlyInAnyOrder
+      listOf("renders", "renders", "renders")
+
+    testFinishes.map {
+      val data = it.data as TestFinish
+      val details = data.data as JUnitStyleTestCaseData
+      details.className to data.status
+    } shouldContainExactlyInAnyOrder
+      listOf(
+        "loading state renders" to TestStatus.FAILED,
+        "success state renders" to TestStatus.PASSED,
+        "skipped state renders" to TestStatus.SKIPPED,
+      )
+  }
+
+  @Test
+  fun `jest system-out - ignores generic target testcase`(
+    @TempDir tempDir: Path,
+  ) {
+    val sampleContents =
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <testsuites>
+        <testsuite name="sample/test" tests="1" failures="0" errors="0">
+          <testcase name="sample/test" status="run" duration="0" time="0"></testcase>
+          <system-out>
+      <![CDATA[PASS node src/example/__tests__/sample.node.ts
+        sample suite
+          ✓ child test (1 ms)
+
+      Test Suites: 1 passed, 1 total
+      Tests:       1 passed, 1 total
+      Time:        1.315 s]]>
+          </system-out>
+        </testsuite>
+      </testsuites>
+      """.trimIndent()
+
+    val client = MockBuildClient()
+    val notifier = BspClientTestNotifier(client, "sample-origin")
+
+    TestXmlParser(notifier).parseAndReport(writeTempFile(tempDir, sampleContents))
+
+    val testFinishes = client.taskFinishCalls.filter { it.data is TestFinish }
+
+    testFinishes.map { (it.data as TestFinish).displayName } shouldContainExactlyInAnyOrder listOf("child test")
+    val details = (testFinishes.single().data as TestFinish).data as JUnitStyleTestCaseData
+    details.className shouldBe "sample suite child test"
+  }
+
+  @Test
+  fun `jest system-out - ignores stdout bullet lines`(
+    @TempDir tempDir: Path,
+  ) {
+    val sampleContents =
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <testsuites>
+        <testsuite name="sample/test" tests="1" failures="0" errors="0">
+          <testcase name="sample/test" status="run" duration="0" time="0"></testcase>
+          <system-out>
+      <![CDATA[PASS node src/example/__tests__/sample.node.ts
+        sample suite
+          ✓ child test (1 ms)
+
+        console output
+          - first logged item
+          - second logged item
+
+      Test Suites: 1 passed, 1 total
+      Tests:       1 passed, 1 total
+      Time:        1.315 s]]>
+          </system-out>
+        </testsuite>
+      </testsuites>
+      """.trimIndent()
+
+    val client = MockBuildClient()
+    val notifier = BspClientTestNotifier(client, "sample-origin")
+
+    TestXmlParser(notifier).parseAndReport(writeTempFile(tempDir, sampleContents))
+
+    val testFinishes = client.taskFinishCalls.filter { it.data is TestFinish }
+
+    testFinishes.map { (it.data as TestFinish).displayName } shouldContainExactlyInAnyOrder listOf("child test")
+  }
+
+  @Test
   fun `junit5 - all failure, multiple testcase`(
     @TempDir tempDir: Path,
   ) {


### PR DESCRIPTION
## Problem
Some JavaScript/TypeScript test runners can produce Bazel XML with only an aggregate failed testcase while the detailed Jest results are present in `system-out`. In that case BSP clients receive only the target-level failure and cannot mark individual Jest test cases accurately.

## Summary
- Detect Jest-style output in XML `system-out` when the normal JUnit testcase data is incomplete.
- Parse Jest pass/fail/skipped lines into individual BSP test notifications.
- Keep the fallback XML behavior for non-Jest output.
- Avoid treating ordinary stdout bullet lines as skipped tests.

## Test plan
- `bazel test //server/server/src/test/kotlin/org/jetbrains/bsp/bazel/server/bep:TestXmlParserTest`
- Manual: installed a local snapshot server and verified Jest child statuses are reported from `system-out` for mixed pass/fail runs.
